### PR TITLE
Use Go Modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/tooolbox/esbuild
+
+go 1.13

--- a/main.go
+++ b/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	cmd "github.com/tooolbox/esbuild/src/esbuild/main"
+)
+
+func main() {
+	cmd.Run()
+}

--- a/src/esbuild/bundler/bundler.go
+++ b/src/esbuild/bundler/bundler.go
@@ -3,17 +3,18 @@ package bundler
 import (
 	"bytes"
 	"encoding/base64"
-	"esbuild/ast"
-	"esbuild/fs"
-	"esbuild/lexer"
-	"esbuild/logging"
-	"esbuild/parser"
-	"esbuild/printer"
-	"esbuild/resolver"
 	"fmt"
 	"sort"
 	"strings"
 	"sync"
+
+	"github.com/tooolbox/esbuild/src/esbuild/ast"
+	"github.com/tooolbox/esbuild/src/esbuild/fs"
+	"github.com/tooolbox/esbuild/src/esbuild/lexer"
+	"github.com/tooolbox/esbuild/src/esbuild/logging"
+	"github.com/tooolbox/esbuild/src/esbuild/parser"
+	"github.com/tooolbox/esbuild/src/esbuild/printer"
+	"github.com/tooolbox/esbuild/src/esbuild/resolver"
 )
 
 type file struct {

--- a/src/esbuild/bundler/bundler_test.go
+++ b/src/esbuild/bundler/bundler_test.go
@@ -1,12 +1,13 @@
 package bundler
 
 import (
-	"esbuild/fs"
-	"esbuild/logging"
-	"esbuild/parser"
-	"esbuild/resolver"
 	"path"
 	"testing"
+
+	"github.com/tooolbox/esbuild/src/esbuild/fs"
+	"github.com/tooolbox/esbuild/src/esbuild/logging"
+	"github.com/tooolbox/esbuild/src/esbuild/parser"
+	"github.com/tooolbox/esbuild/src/esbuild/resolver"
 )
 
 func assertEqual(t *testing.T, a interface{}, b interface{}) {

--- a/src/esbuild/bundler/bundler_ts_test.go
+++ b/src/esbuild/bundler/bundler_ts_test.go
@@ -1,12 +1,13 @@
 package bundler
 
 import (
-	"esbuild/fs"
-	"esbuild/logging"
-	"esbuild/parser"
-	"esbuild/resolver"
 	"path"
 	"testing"
+
+	"github.com/tooolbox/esbuild/src/esbuild/fs"
+	"github.com/tooolbox/esbuild/src/esbuild/logging"
+	"github.com/tooolbox/esbuild/src/esbuild/parser"
+	"github.com/tooolbox/esbuild/src/esbuild/resolver"
 )
 
 func expectBundledTS(t *testing.T, args bundled) {

--- a/src/esbuild/bundler/renamer.go
+++ b/src/esbuild/bundler/renamer.go
@@ -1,10 +1,11 @@
 package bundler
 
 import (
-	"esbuild/ast"
-	"esbuild/lexer"
 	"sort"
 	"strconv"
+
+	"github.com/tooolbox/esbuild/src/esbuild/ast"
+	"github.com/tooolbox/esbuild/src/esbuild/lexer"
 )
 
 func reservedNames(moduleScopes []*ast.Scope, symbols *ast.SymbolMap) map[string]bool {

--- a/src/esbuild/lexer/lexer.go
+++ b/src/esbuild/lexer/lexer.go
@@ -14,14 +14,15 @@ package lexer
 // accurately.
 
 import (
-	"esbuild/ast"
-	"esbuild/logging"
 	"fmt"
 	"strconv"
 	"strings"
 	"unicode"
 	"unicode/utf16"
 	"unicode/utf8"
+
+	"github.com/tooolbox/esbuild/src/esbuild/ast"
+	"github.com/tooolbox/esbuild/src/esbuild/logging"
 )
 
 type T uint

--- a/src/esbuild/lexer/lexer_test.go
+++ b/src/esbuild/lexer/lexer_test.go
@@ -1,12 +1,13 @@
 package lexer
 
 import (
-	"esbuild/logging"
 	"fmt"
 	"math"
 	"strings"
 	"testing"
 	"unicode/utf8"
+
+	"github.com/tooolbox/esbuild/src/esbuild/logging"
 )
 
 func assertEqual(t *testing.T, a interface{}, b interface{}) {

--- a/src/esbuild/logging/logging.go
+++ b/src/esbuild/logging/logging.go
@@ -6,13 +6,14 @@ package logging
 // default.
 
 import (
-	"esbuild/ast"
 	"fmt"
 	"os"
 	"os/exec"
 	"runtime"
 	"strconv"
 	"strings"
+
+	"github.com/tooolbox/esbuild/src/esbuild/ast"
 )
 
 type Log struct {

--- a/src/esbuild/main/main.go
+++ b/src/esbuild/main/main.go
@@ -1,13 +1,6 @@
-package main
+package cmd
 
 import (
-	"esbuild/ast"
-	"esbuild/bundler"
-	"esbuild/fs"
-	"esbuild/lexer"
-	"esbuild/logging"
-	"esbuild/parser"
-	"esbuild/resolver"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -17,6 +10,14 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/tooolbox/esbuild/src/esbuild/ast"
+	"github.com/tooolbox/esbuild/src/esbuild/bundler"
+	"github.com/tooolbox/esbuild/src/esbuild/fs"
+	"github.com/tooolbox/esbuild/src/esbuild/lexer"
+	"github.com/tooolbox/esbuild/src/esbuild/logging"
+	"github.com/tooolbox/esbuild/src/esbuild/parser"
+	"github.com/tooolbox/esbuild/src/esbuild/resolver"
 )
 
 type args struct {
@@ -329,7 +330,7 @@ Examples:
 	return args
 }
 
-func main() {
+func Run() {
 	start := time.Now()
 	args := parseArgs()
 

--- a/src/esbuild/main/version.go
+++ b/src/esbuild/main/version.go
@@ -1,3 +1,3 @@
-package main
+package cmd
 
 const esbuildVersion = "0.0.16"

--- a/src/esbuild/parser/parser.go
+++ b/src/esbuild/parser/parser.go
@@ -1,14 +1,15 @@
 package parser
 
 import (
-	"esbuild/ast"
-	"esbuild/lexer"
-	"esbuild/logging"
 	"fmt"
 	"math"
 	"reflect"
 	"strings"
 	"unsafe"
+
+	"github.com/tooolbox/esbuild/src/esbuild/ast"
+	"github.com/tooolbox/esbuild/src/esbuild/lexer"
+	"github.com/tooolbox/esbuild/src/esbuild/logging"
 )
 
 // This parser does two passes:

--- a/src/esbuild/parser/parser_json.go
+++ b/src/esbuild/parser/parser_json.go
@@ -1,9 +1,9 @@
 package parser
 
 import (
-	"esbuild/ast"
-	"esbuild/lexer"
-	"esbuild/logging"
+	"github.com/tooolbox/esbuild/src/esbuild/ast"
+	"github.com/tooolbox/esbuild/src/esbuild/lexer"
+	"github.com/tooolbox/esbuild/src/esbuild/logging"
 )
 
 type jsonParser struct {

--- a/src/esbuild/parser/parser_test.go
+++ b/src/esbuild/parser/parser_test.go
@@ -1,11 +1,12 @@
 package parser
 
 import (
-	"esbuild/ast"
-	"esbuild/logging"
-	"esbuild/printer"
 	"fmt"
 	"testing"
+
+	"github.com/tooolbox/esbuild/src/esbuild/ast"
+	"github.com/tooolbox/esbuild/src/esbuild/logging"
+	"github.com/tooolbox/esbuild/src/esbuild/printer"
 )
 
 func assertEqual(t *testing.T, a interface{}, b interface{}) {

--- a/src/esbuild/parser/parser_ts_test.go
+++ b/src/esbuild/parser/parser_ts_test.go
@@ -1,9 +1,10 @@
 package parser
 
 import (
-	"esbuild/logging"
-	"esbuild/printer"
 	"testing"
+
+	"github.com/tooolbox/esbuild/src/esbuild/logging"
+	"github.com/tooolbox/esbuild/src/esbuild/printer"
 )
 
 func expectParseErrorTS(t *testing.T, contents string, expected string) {

--- a/src/esbuild/printer/printer.go
+++ b/src/esbuild/printer/printer.go
@@ -2,12 +2,13 @@ package printer
 
 import (
 	"bytes"
-	"esbuild/ast"
-	"esbuild/lexer"
 	"fmt"
 	"math"
 	"strconv"
 	"strings"
+
+	"github.com/tooolbox/esbuild/src/esbuild/ast"
+	"github.com/tooolbox/esbuild/src/esbuild/lexer"
 )
 
 var base64 = []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/")

--- a/src/esbuild/printer/printer_test.go
+++ b/src/esbuild/printer/printer_test.go
@@ -1,9 +1,10 @@
 package printer
 
 import (
-	"esbuild/logging"
-	"esbuild/parser"
 	"testing"
+
+	"github.com/tooolbox/esbuild/src/esbuild/logging"
+	"github.com/tooolbox/esbuild/src/esbuild/parser"
 )
 
 func assertEqual(t *testing.T, a interface{}, b interface{}) {

--- a/src/esbuild/resolver/resolver.go
+++ b/src/esbuild/resolver/resolver.go
@@ -1,13 +1,14 @@
 package resolver
 
 import (
-	"esbuild/ast"
-	"esbuild/fs"
-	"esbuild/lexer"
-	"esbuild/logging"
-	"esbuild/parser"
 	"strings"
 	"sync"
+
+	"github.com/tooolbox/esbuild/src/esbuild/ast"
+	"github.com/tooolbox/esbuild/src/esbuild/fs"
+	"github.com/tooolbox/esbuild/src/esbuild/lexer"
+	"github.com/tooolbox/esbuild/src/esbuild/logging"
+	"github.com/tooolbox/esbuild/src/esbuild/parser"
 )
 
 type ResolveStatus uint8


### PR DESCRIPTION
This PR adopts Go Modules with minimal changes to the project structure, with the intention that it can be regularly synchronized to upstream.